### PR TITLE
Docs update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,16 @@
 version = 3
 
 [[package]]
-name = "basic-toml"
-version = "0.1.4"
+name = "bytemuck"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
-dependencies = [
- "serde",
-]
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 
 [[package]]
-name = "bytemuck"
-version = "1.13.1"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "glob"
@@ -24,60 +21,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "include_data"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bytemuck",
  "trybuild",
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.9"
+name = "indexmap"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
+name = "itoa"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "memchr"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -86,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -96,10 +112,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.26"
+name = "serde_spanned"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -108,61 +133,154 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
-name = "trybuild"
-version = "1.0.81"
+name = "toml"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04366e99ff743345622cd00af2af01d711dc2d1ef59250d7347698d21b546729"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
- "basic-toml",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a5f13f11071020bb12de7a16b925d2d58636175c20c11dc5f96cb64bb6c9b3"
+dependencies = [
  "glob",
- "once_cell",
  "serde",
  "serde_derive",
  "serde_json",
  "termcolor",
+ "toml",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "include_data"
 description = "Include typed data directly in your executable"
 authors = ["jmaargh <https://github.com/jmaargh>"]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/jmaargh/include_data"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ includes. This is provided by two main macros:
 
 - `include_data` - outputs any type which is sound
 - `include_slice` - outputs a `&'static [T]` slice for any `T` for which
-                    this is sound
+  this is sound
 
 This crate is `no_std` and also no-`alloc`.
 
@@ -40,6 +40,7 @@ This includes:
 - Arrays of primitive numerical types (e.g. `[f32; N]`)
 
 For example:
+
 ```rust
 static MY_INTEGER: i32 = include_data!("../tests/test_data/file_exactly_4_bytes_long");
 static SOME_TEXT: &[u32] = include_slice!(u32, "../tests/test_data/some_utf-32_file");
@@ -50,6 +51,7 @@ Note that `include_data` can assign to `const`, while `include_slice` cannot.
 
 Aliases are provided for `include_slice` for primitive number types, using
 them is a matter of personal preference. For example:
+
 ```rust
 static SOME_TEXT: &[u32] = include_u32s!("../tests/test_data/some_utf-32_file");
 ```
@@ -127,6 +129,27 @@ The Minimum Supported Rust Version is **1.64.0**.
 Note that this crate is tested against a pinned version of the compiler,
 simply because many tests check exact error messages. The current pinned
 version for testing purposes can be found in `rust-toolchain.toml`.
+
+## Alternatives
+
+Depending on what you're trying to achieve, this crate might not be the best
+choice. Here are a few alternatives which may be more appropriate depending
+on the situation:
+
+- [`static_toml`](https://crates.io/crates/static-toml): if the data you're
+  including fits within a `toml` spec, this crate parses it at compile time
+  and includes the result as static, type-safe, data.
+- [`const_gen`](https://crates.io/crates/const-gen): tool that helps you use
+  `build.rs` to do compile-time code generation of constant values. More
+  complicated and verbose than `include_data`, but also more flexible.
+- The standard library has [`OnceLock`](https://doc.rust-lang.org/stable/std/sync/struct.OnceLock.html)
+  and [`LazyLock`](https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html)
+  both of which can be used to assign complex values to `static`s, but do so
+  at runtime and with a non-zero runtime cost. If your type needs runtime
+  construction, these are very good chocies but `include_data` is cheaper
+  for "simple typed data" values.
+
+If you know of any others, please drop an issue or open a PR.
 
 ## Prior art
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,6 @@ includes. This is provided by two main macros:
 
 This crate is `no_std` and also no-`alloc`.
 
-## Stability
-
-While this crate is pre-1.0 both the API and semantics should be considered
-unstable. However, this is simply to allow thorough community-review of the
-soundness of implementation. I hope that a 1.0 release will come relatively
-quickly with few API changes.
-
 ## Usage
 
 This library will work out-of-the-box with any type that implements

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.64.0"
+channel = "1.70.0"
 components = ["rustfmt", "clippy"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,15 +50,16 @@
 //! docs for more details.
 //! ```
 //! # use include_data::include_unsafe;
+//! // This struct contains a `bool`, which is only valid for bit patterns of
+//! // 0x00 and 0x01, so does not satisfy `bytemuck::AnyBitPattern` and thus
+//! // requires `include_unsafe`.
 //! #[repr(C)]
-//! struct StructWithPadding {
-//!     byte: u8,
+//! struct StructWithBool {
+//!     boolean: bool,
 //!     two_bytes: u16,
 //! }
 //!
-//! // Safety: we guarantee that the included file contains bytes which are
-//! // a valid bit-pattern for our struct, when compiled on this host.
-//! static BAR_DATA: StructWithPadding = unsafe { include_unsafe!("../tests/test_data/file_exactly_4_bytes_long") };
+//! static BAR_DATA: StructWithBool = unsafe { include_unsafe!("../tests/test_data/file_exactly_4_bytes_long") };
 //! ```
 //!
 //! ## Platform-specific behaviour
@@ -152,15 +153,23 @@ macro_rules! include_data {
 ///
 /// ```
 /// # use include_data::include_unsafe;
+/// // This struct contains a `bool`, which is only valid for bit patterns of
+/// // 0x00 and 0x01, so does not satisfy `bytemuck::AnyBitPattern` and thus
+/// // requires `include_unsafe`.
 /// #[repr(C)]
-/// struct StructWithPadding {
-///     byte: u8,
+/// struct StructWithBool {
+///     boolean: bool,
 ///     two_bytes: u16,
 /// }
 ///
 /// // Safety: we guarantee that the included file contains bytes which are
 /// // a valid bit-pattern for our struct, when compiled on this host.
-/// static BAR_DATA: StructWithPadding = unsafe { include_unsafe!("../tests/test_data/file_exactly_4_bytes_long") };
+/// // This file contains bytes 0x01 0x00 0x02 0x03 in that order. The padding
+/// // byte (second byte) could be any value, but the first byte has to be
+/// // valid for `bool`.
+/// static BAR_DATA: StructWithBool = unsafe { include_unsafe!("../tests/test_data/file_exactly_4_bytes_long") };
+///
+/// # assert_eq!(BAR_DATA.boolean, true);
 /// ```
 ///
 /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,27 @@
 //!
 //! The interpreation of paths passed to these macros is host-platform specific
 //! and identical to that of [`core::include_bytes`].
+//!
+//! ## Alternatives
+//!
+//! Depending on what you're trying to achieve, this crate might not be the best
+//! choice. Here are a few alternatives which may be more appropriate depending
+//! on the situation:
+//!
+//! - [`static_toml`](https://crates.io/crates/static-toml): if the data you're
+//!   including fits within a `toml` spec, this crate parses it at compile time
+//!   and includes the result as static, type-safe, data.
+//! - [`const_gen`](https://crates.io/crates/const-gen): tool that helps you use
+//!   `build.rs` to do compile-time code generation of constant values. More
+//!   complicated and verbose than `include_data`, but also more flexible.
+//! - The standard library has [`OnceLock`](https://doc.rust-lang.org/stable/std/sync/struct.OnceLock.html)
+//!   and [`LazyLock`](https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html)
+//!   both of which can be used to assign complex values to `static`s, but do so
+//!   at runtime and with a non-zero runtime cost. If your type needs runtime
+//!   construction, these are very good chocies but `include_data` is cheaper
+//!   for "simple typed data" values.
+//!
+//! If you know of any others, please drop an issue or open a PR.
 
 #[doc(hidden)]
 pub use bytemuck;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,27 +71,6 @@
 //!
 //! The interpreation of paths passed to these macros is host-platform specific
 //! and identical to that of [`core::include_bytes`].
-//!
-//! ## Alternatives
-//!
-//! Depending on what you're trying to achieve, this crate might not be the best
-//! choice. Here are a few alternatives which may be more appropriate depending
-//! on the situation:
-//!
-//! - [`static_toml`](https://crates.io/crates/static-toml): if the data you're
-//!   including fits within a `toml` spec, this crate parses it at compile time
-//!   and includes the result as static, type-safe, data.
-//! - [`const_gen`](https://crates.io/crates/const-gen): tool that helps you use
-//!   `build.rs` to do compile-time code generation of constant values. More
-//!   complicated and verbose than `include_data`, but also more flexible.
-//! - The standard library has [`OnceLock`](https://doc.rust-lang.org/stable/std/sync/struct.OnceLock.html)
-//!   and [`LazyLock`](https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html)
-//!   both of which can be used to assign complex values to `static`s, but do so
-//!   at runtime and with a non-zero runtime cost. If your type needs runtime
-//!   construction, these are very good chocies but `include_data` is cheaper
-//!   for "simple typed data" values.
-//!
-//! If you know of any others, please drop an issue or open a PR.
 
 #[doc(hidden)]
 pub use bytemuck;

--- a/tests/bad/include_data/not_anybitpattern.stderr
+++ b/tests/bad/include_data/not_anybitpattern.stderr
@@ -2,7 +2,11 @@ error[E0277]: the trait bound `char: Pod` is not satisfied
  --> tests/bad/include_data/not_anybitpattern.rs:3:24
   |
 3 | static NOT_ABP: char = include_data::include_data!("../../test_data/binary_4");
-  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Pod` is not implemented for `char`
+  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                        |
+  |                        the trait `Pod` is not implemented for `char`
+  |                        this tail expression is of type `char`
+  |                        required by a bound introduced by this call
   |
   = help: the following other types implement trait `Pod`:
             ()
@@ -14,19 +18,23 @@ error[E0277]: the trait bound `char: Pod` is not satisfied
             [T; N]
             __m128
           and $N others
-  = note: required because of the requirements on the impl of `AnyBitPattern` for `char`
+  = note: required for `char` to implement `AnyBitPattern`
 note: required by a bound in `NOT_ABP::typecheck`
  --> tests/bad/include_data/not_anybitpattern.rs:3:24
   |
 3 | static NOT_ABP: char = include_data::include_data!("../../test_data/binary_4");
-  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NOT_ABP::typecheck`
+  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `typecheck`
   = note: this error originates in the macro `include_data::include_data` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Foo: Pod` is not satisfied
  --> tests/bad/include_data/not_anybitpattern.rs:9:30
   |
 9 | static NOT_ABP_CUSTOM: Foo = include_data::include_data!("../../test_data/binary_2");
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Pod` is not implemented for `Foo`
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                              |
+  |                              the trait `Pod` is not implemented for `Foo`
+  |                              this tail expression is of type `Foo`
+  |                              required by a bound introduced by this call
   |
   = help: the following other types implement trait `Pod`:
             ()
@@ -38,10 +46,10 @@ error[E0277]: the trait bound `Foo: Pod` is not satisfied
             [T; N]
             __m128
           and $N others
-  = note: required because of the requirements on the impl of `AnyBitPattern` for `Foo`
+  = note: required for `Foo` to implement `AnyBitPattern`
 note: required by a bound in `NOT_ABP_CUSTOM::typecheck`
  --> tests/bad/include_data/not_anybitpattern.rs:9:30
   |
 9 | static NOT_ABP_CUSTOM: Foo = include_data::include_data!("../../test_data/binary_2");
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NOT_ABP_CUSTOM::typecheck`
+  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `typecheck`
   = note: this error originates in the macro `include_data::include_data` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/bad/include_slice/bool.stderr
+++ b/tests/bad/include_slice/bool.stderr
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `bool: Pod` is not satisfied
             [T; N]
             __m128
           and $N others
-  = note: required because of the requirements on the impl of `AnyBitPattern` for `bool`
+  = note: required for `bool` to implement `AnyBitPattern`
 note: required by a bound in `AlignedAs`
  --> src/lib.rs
   |

--- a/tests/bad/include_slice/f32_f64.stderr
+++ b/tests/bad/include_slice/f32_f64.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
  --> tests/bad/include_slice/f32_f64.rs:4:35
   |
 4 | static BYTES_32_f32_f64: &[f32] = include_data::include_slice!(f64, "../../test_data/binary_32");
-  |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `f32`, found `f64`
+  |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&[f32]`, found `&[f64]`
   |
   = note: expected reference `&'static [f32]`
              found reference `&'static [f64]`

--- a/tests/bad/include_slice/missing_file.stderr
+++ b/tests/bad/include_slice/missing_file.stderr
@@ -5,14 +5,3 @@ error: couldn't read $DIR/tests/bad/include_slice/../../test_data/non-existent: 
   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `::core::include_bytes` which comes from the expansion of the macro `include_data::include_slice` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
- --> tests/bad/include_slice/missing_file.rs:4:27
-  |
-4 | static BYTES_31: &[i32] = include_data::include_slice!(i32, "../../test_data/non-existent");
-  |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-  |
-  = help: within `AlignedAs<i32, [u8]>`, the trait `Sized` is not implemented for `[u8]`
-  = note: required because it appears within the type `AlignedAs<i32, [u8]>`
-  = note: structs must have a statically known size to be initialized
-  = note: this error originates in the macro `include_data::include_slice` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/bad/include_slice/not_anybitpattern.stderr
+++ b/tests/bad/include_slice/not_anybitpattern.stderr
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `bool: Pod` is not satisfied
             [T; N]
             __m128
           and $N others
-  = note: required because of the requirements on the impl of `AnyBitPattern` for `bool`
+  = note: required for `bool` to implement `AnyBitPattern`
 note: required by a bound in `AlignedAs`
  --> src/lib.rs
   |
@@ -38,7 +38,7 @@ error[E0277]: the trait bound `Foo: Pod` is not satisfied
             [T; N]
             __m128
           and $N others
-  = note: required because of the requirements on the impl of `AnyBitPattern` for `Foo`
+  = note: required for `Foo` to implement `AnyBitPattern`
 note: required by a bound in `AlignedAs`
  --> src/lib.rs
   |

--- a/tests/bad/include_slice/u8_u16.stderr
+++ b/tests/bad/include_slice/u8_u16.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
  --> tests/bad/include_slice/u8_u16.rs:4:33
   |
 4 | static BYTES_32_u8_u16: &[u8] = include_data::include_slice!(u16, "../../test_data/binary_32");
-  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `u16`
+  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&[u8]`, found `&[u16]`
   |
   = note: expected reference `&'static [u8]`
              found reference `&'static [u16]`

--- a/tests/include_unsafe.rs
+++ b/tests/include_unsafe.rs
@@ -3,18 +3,20 @@ use include_data::include_unsafe;
 #[test]
 fn with_padding() {
     #[repr(C)]
-    struct StructWithPadding {
-        byte: u8,
+    struct StructWithBools {
+        bool1: bool,
+        bool2: bool,
         two_bytes: u16,
     }
 
-    // Safety: we guarantee that the included file contains bytes which are
-    // a valid bit-pattern for our struct, when compiled on this host.
-    static BAR_DATA: StructWithPadding =
+    // Safety: we guarantee that the included file contains the bytes 0x00 and
+    // 0x01 at the start, which are both valid bool bit patterns.
+    static BAR_DATA: StructWithBools =
         unsafe { include_unsafe!("../tests/test_data/file_exactly_4_bytes_long") };
 
-    assert_eq!(core::mem::size_of::<StructWithPadding>(), 4);
-    assert_eq!(BAR_DATA.byte, 0x01);
+    assert_eq!(core::mem::size_of::<StructWithBools>(), 4);
+    assert_eq!(BAR_DATA.bool1, true);
+    assert_eq!(BAR_DATA.bool2, false);
     if cfg!(target_endian = "little") {
         assert_eq!(BAR_DATA.two_bytes, 0x0302);
     } else {


### PR DESCRIPTION
- Fixes docs for `include_unsafe` to replace misleading example with a better one
- Adds "alternatives" to readme to point at other useful solutions for similar problems
- Removes unnecessary "stability" section from readme
- Updates dependencies and testing Rust version